### PR TITLE
Revoke access

### DIFF
--- a/resources/declarative-provision/charts/declarative-provision/values.yaml
+++ b/resources/declarative-provision/charts/declarative-provision/values.yaml
@@ -4,8 +4,6 @@ namespace: intranet-front
 groups:
   - name: intranet-devs
     role: edit
-  - name: intranet-managers
-    role: view
 
 resourceQuotas:
   pods: 8


### PR DESCRIPTION
The managers of intranet project do not need access to the development environment 

Att: Nicolas Simon cluster admin :-)